### PR TITLE
Logging NZBLNKs to a file

### DIFF
--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -17,7 +17,7 @@ import webbrowser
 import xml.etree.ElementTree as ET
 from enum import Enum
 from glob import glob
-from os.path import basename, splitext, isfile, join, expandvars
+from os.path import basename, splitext, isfile, join, expandvars, expanduser
 from pathlib import Path
 from time import sleep, time, localtime, strftime
 from unicodedata import normalize
@@ -1385,6 +1385,11 @@ def main():
     else:
         debug_logfile = None
 
+    log = cfg['GENERAL'].get('log')
+    if log:
+        logfile = cfg['GENERAL'].get('logpath') 
+        logfile = os.path.expanduser(logfile)
+        
     # region Processing Input
     parser = argparse.ArgumentParser()
     parser.add_argument('-t', '--tag', action='store', help='Tag for Releasename')
@@ -1401,6 +1406,10 @@ def main():
 
     if len(args.nzblnk) > 0:
         called_by = 'by NZBLNK scheme'
+
+        if log:
+            f=open(logfile,'a+')
+            f.write(args.nzblnk[0])
 
         lnk = urlparse(args.nzblnk[0])
         if lnk.scheme.lower() != 'nzblnk':

--- a/src/nzbmonkey.py
+++ b/src/nzbmonkey.py
@@ -1387,8 +1387,14 @@ def main():
 
     log = cfg['GENERAL'].get('log')
     if log:
-        logfile = cfg['GENERAL'].get('logpath') 
-        logfile = os.path.expanduser(logfile)
+        nzblogfile = cfg['GENERAL'].get('logpath') 
+        if nzblogfile != None:
+            nzblogfile = os.path.expanduser(nzblogfile)
+            print ('Logging to '+nzblogfile)
+        else:
+            print ("logpath config in [GENERAL] is missing!")
+            log=None
+        
         
     # region Processing Input
     parser = argparse.ArgumentParser()
@@ -1408,8 +1414,8 @@ def main():
         called_by = 'by NZBLNK scheme'
 
         if log:
-            f=open(logfile,'a+')
-            f.write(args.nzblnk[0])
+            f=open(nzblogfile,'a+')
+            f.write(args.nzblnk[0]+'\n')
 
         lnk = urlparse(args.nzblnk[0])
         if lnk.scheme.lower() != 'nzblnk':


### PR DESCRIPTION
I wanted to log the NZBLNKs to a file to be able to redownload when a file is accidently deleted. Therefor I implemented a few lines to log to a configurable destination.

Configuration works as follows:

```
[GENERAL]
log = True
logpath = /path/to/log.ext
```
On Linux, OSX ~ is expanded to the users home directory. Windows should work as well, but is not tested.